### PR TITLE
Ignore ActionController::InvalidAuthenticityToken

### DIFF
--- a/config/initializers/exception_notification.rb
+++ b/config/initializers/exception_notification.rb
@@ -1,11 +1,9 @@
 require 'exception_notification/rails'
 
-
-
 ExceptionNotification.configure do |config|
   # Ignore additional exception types.
   # ActiveRecord::RecordNotFound, AbstractController::ActionNotFound and ActionController::RoutingError are already added.
-  # config.ignored_exceptions += %w{ActionView::TemplateError CustomError}
+  config.ignored_exceptions += %w{ActionController::InvalidAuthenticityToken}
 
   # Adds a condition to decide when an exception must be ignored or not.
   # The ignore_if method can be invoked multiple times to add extra conditions.


### PR DESCRIPTION
These exceptions should surface in development (unless you're not testing your forms) and can safely be ignored in production as they tend to be caused by spam bots.
