### PR TITLE
Fixes failing spec for RegistrantsController

### DIFF
--- a/spec/controllers/registrants_controller_spec.rb
+++ b/spec/controllers/registrants_controller_spec.rb
@@ -27,7 +27,7 @@ describe RegistrantsController do
       existing_registrant.reload
       existing_registrant.language.should == 'french'
       existing_registrant.bringing_laptop.should be_true
-      existing_registrant.course.should == 'beginner'
+      existing_registrant.level.should == 'beginner'
     end
   end
 
@@ -37,7 +37,7 @@ describe RegistrantsController do
     "registrant"=> {
       "name"=>"",
       "email"=>"",
-      "programmed_before"=>"no",
+      "programmed_before"=>"false",
       "bringing_laptop"=>"true",
       "language"=>"french",
       "special_needs"=>""


### PR DESCRIPTION
I went to upgrade Rails today, but discovered a failing spec. Strange since the build on TravisCI is green. Can someone verifying that I'm not missing something obvious here?
